### PR TITLE
New feature: Cache results

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,4 @@ services:
       - WEKAN_PASSWORD=admin
       - LISTEN_HOST=0.0.0.0
       - LISTEN_PORT=8091
+      - CACHE_SEC=-1

--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,2 @@
 vobject
-wekanapi @ git+https://github.com/wekan/wekan-python-api-client.git@7c4a75dd218a413c1f27d3db5acae56d63bb3706#subdirectory=src
+wekanapi @ git+https://github.com/wekan/wekan-python-api-client.git@82ae0b685fc2bd74a52401e2716551e59a3df019#subdirectory=src

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ urllib3==1.26.3
     # via requests
 vobject==0.9.6.1
     # via -r requirements.in
-git+https://github.com/wekan/wekan-python-api-client.git@7c4a75dd218a413c1f27d3db5acae56d63bb3706#subdirectory=src
+git+https://github.com/wekan/wekan-python-api-client.git@82ae0b685fc2bd74a52401e2716551e59a3df019#subdirectory=src
     # via -r requirements.in


### PR DESCRIPTION
Currently, one request takes ~10 seconds to respond.
If there are multiple clients requesting at the same time it will cause a long waiting time. Multiple such requests will flood the wekan server.
This PR adds one option: "CACHE_SEC". This helps the user to control how often (in seconds) should ical-server cache results. If multiple clients request within this time frame, the server simply returns a cached result.

By default, CACHE_SEC is -1, which means we do not enable cache feature. So this fix will make default behavior consistent with previous versions.